### PR TITLE
Add input field component

### DIFF
--- a/src/components/InputField/InputField.style.ts
+++ b/src/components/InputField/InputField.style.ts
@@ -1,0 +1,62 @@
+import {InputSize, InputStyle, InputState, InputIconPosition} from "./InputField.types.ts";
+import clsx from "clsx";
+
+export function getInputFieldStyle(size: InputSize,
+                                   style: InputStyle,
+                                   state: InputState,
+                                   iconPosition?: InputIconPosition
+) {
+
+    const baseClasses = 'w-full px-2 py-2 peer border-1 rounded-md focus:outline-none focus:ring-1 focus:ring-green-400';
+
+    const sizeClasses = {
+        sm: 'text-sm h-10',
+        md: 'text-md h-11',
+        lg: 'text-xl h-13',
+    };
+
+    const iconSizeClasses = {
+        sm: 14,
+        md: 18,
+        lg: 22,
+    }
+
+    const paddingWithIcon = {
+        sm: 'pl-8',
+        md: 'pl-10',
+        lg: 'pl-12',
+    };
+
+    const paddingWithIconRight = {
+        sm: 'pr-8',
+        md: 'pr-10',
+        lg: 'pr-12',
+    };
+
+    const styleClasses = {
+        primary: 'bg-green-200/10 border-green-500 text-green-950',
+        secondary: 'bg-green-200 border-green-500 text-black',
+    };
+
+    const hoverClasses = {
+        primary: 'hover:border-green-400 hover:bg-green-200/15',
+        secondary: 'hover:bg-green-200/90',
+    }
+
+    const stateClasses = {
+        enabled: clsx('hover:cursor-text opacity-100', hoverClasses[style]),
+        disabled: 'opacity-50 cursor-not-allowed',
+    };
+
+    const iconPadding = iconPosition === 'left'
+        ? paddingWithIcon[size]
+        : iconPosition === 'right'
+            ? paddingWithIconRight[size]
+            : '';
+
+
+    const inputStyle = clsx(baseClasses, sizeClasses[size], styleClasses[style], stateClasses[state], iconPadding);
+    const iconSize = iconSizeClasses[size];
+
+    return {inputStyle, iconSize};
+}

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,0 +1,43 @@
+import {InputFieldProps} from './InputField.types.ts'
+import {getInputFieldStyle} from "./InputField.style.ts";
+
+export default function InputField({
+                                       id = '',
+                                       label = '',
+                                       style = 'primary',
+                                       size = 'md',
+                                       state = 'enabled',
+                                       type = 'text',
+                                       icon: Icon,
+                                       iconPosition = 'left',
+                                       onChange,
+                                   }: InputFieldProps) {
+
+    const {inputStyle, iconSize} = getInputFieldStyle(size, style, state, Icon ? iconPosition : 'alone');
+    const isDisabled = state === 'disabled';
+
+    return (
+        <div className="relative w-full">
+            {Icon && iconPosition === 'left' && (
+                <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <Icon size={iconSize}/>
+                </div>
+            )}
+
+            <input
+                type={type}
+                id={id}
+                className={inputStyle}
+                placeholder={label}
+                onChange={onChange}
+                disabled={isDisabled}
+            />
+
+            {Icon && iconPosition === 'right' && (
+                <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                    <Icon size={iconSize}/>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/InputField/InputField.types.ts
+++ b/src/components/InputField/InputField.types.ts
@@ -1,0 +1,20 @@
+import {LucideIcon} from "lucide-react";
+
+export type InputStyle = 'primary' | 'secondary';
+export type InputSize = 'sm' | 'md' | 'lg';
+export type InputIconPosition = 'left' | 'right' | 'alone';
+export type InputState = 'enabled' | 'disabled';
+export type InputType = 'date' | 'email' | 'text' | 'password' | 'number' | 'search';
+
+
+export interface InputFieldProps {
+    id?: string;
+    label?: string;
+    style?: InputStyle;
+    size?: InputSize;
+    state?: InputState;
+    type?: InputType;
+    icon?: LucideIcon;
+    iconPosition?: InputIconPosition;
+    onChange?: () => void;
+}


### PR DESCRIPTION
## 📌 Description

This PR introduces the `InputField` component to the NexusTech design system, providing a flexible and accessible input element with support for various styles, sizes, and states.

## 🔍 Related Issues

No related issues.

## ✨ Changes Made

- Created `InputField` component with customizable props
- Supported input types: `text`, `email`, `password`, `number`, `search`, and `date`
- Added style variants: `primary` and `secondary`
- Implemented sizes: `sm`, `md`, `lg`
- Included `enabled` and `disabled` states
- Integrated optional icon with position options: `left`, `right`, `alone`
- Ensured basic accessibility with `label` and `id` support

## ✅ Checklist

- [x] My code follows the project's coding standards and guidelines  
- [x] I have tested the changes locally to ensure they work as expected  
- [x] No new warnings or errors in the console  
- [x] The UI and functionality are responsive across different screen sizes  

## 🚀 Additional Notes

The `InputField` is designed to be fully reusable and extendable. Icon rendering uses `LucideIcon`, and future improvements may include validation feedback or helper text.