### PR TITLE
feat:  add ProtectedRoute component to restrict access to authenticat…

### DIFF
--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import { Navigate } from "react-router-dom";
+import { useAuth} from "../../assets/contexts/AuthContext.tsx";
+import { ReactNode } from "react";
+
+interface ProtectedRouteProps {
+    children: ReactNode;
+}
+
+const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
+    const { user } = useAuth();
+
+    if (!user) {
+        return <Navigate to="/login" replace />;
+    }
+
+    return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## 📌 Description

This PR adds the `ProtectedRoute` component to restrict access to specific pages for authenticated users only, ensuring route-level protection using Firebase authentication.

## 🔍 Related Issues

N/A

## ✨ Changes Made

- Created `ProtectedRoute.tsx` component
- Integrated `ProtectedRoute` into routing logic
- Ensured that only authenticated users can access protected pages

## ✅ Checklist

- [x] My code follows the project's coding standards and guidelines  
- [x] I have tested the changes locally to ensure they work as expected  
- [x] No new warnings or errors in the console  
- [x] The UI and functionality are responsive across different screen sizes  
- [ ] I have updated the documentation (if necessary)

## 🚀 Additional Notes

This is the foundation for securing private routes; additional role-based protections (e.g. admin-only) can be layered later if needed.